### PR TITLE
issue #3 workaround: schedule rendering upon item change out of the current event chain

### DIFF
--- a/src/modules/init.js
+++ b/src/modules/init.js
@@ -24,9 +24,12 @@ Hooks.on("updateUser", (user, data, options, userId) => {
 });
 
 Hooks.on("updateActor", (actor, data, options, userId) => {
-  if (actor.id === game.user.character?.id) ui.ammoSwapper?.render();
+  if (actor.id === game.user.character?.id) 
+	  setTimeout(()=>{ui.ammoSwapper?.render()});
+  
 });
 
 Hooks.on("updateOwnedItem", (actor, item, data, options, userId) => {
-  if (actor.id === game.user.character?.id) ui.ammoSwapper?.render();
+  if (actor.id === game.user.character?.id) 
+	  setTimeout(()=>{ui.ammoSwapper?.render()});
 });


### PR DESCRIPTION
Testing out some way to resolve the issue #3 I found that it is solved by performing the rendering out of the current event chain. Else the rendering apparently occurs befor the update and it finds the older ammo type.
I called this a workaround because with my actual knowledge of the framework it is more of a wild guess rather than a solid hypothesis.